### PR TITLE
Add benchmarks for batch write 

### DIFF
--- a/badgerstore.go
+++ b/badgerstore.go
@@ -41,16 +41,14 @@ func (s *badgerStore) Close() error {
 }
 
 func (s *badgerStore) PSet(keys, vals [][]byte) error {
-	txn := s.db.NewTransaction(true)
-	for i, k := range keys {
-		v := vals[i]
-		if err := txn.Set(k, v); err == badger.ErrTxnTooBig {
-			_ = txn.Commit()
-			txn = s.db.NewTransaction(true)
-			_ = txn.Set(k, v)
+	wb := s.db.NewWriteBatch()
+	for i := range keys {
+		err := wb.Set(keys[i], vals[i])
+		if err != nil {
+			return err
 		}
 	}
-	return txn.Commit()
+	return wb.Flush()
 }
 
 func (s *badgerStore) PGet(keys [][]byte) ([][]byte, []bool, error) {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -17,8 +17,9 @@ import (
 
 var (
 	duration = flag.Duration("d", time.Minute, "test duration for each case")
-	c        = flag.Int("c", runtime.GOMAXPROCS(-1), "concurrent goroutines")
+	c        = flag.Int("c", runtime.NumCPU(), "concurrent goroutines")
 	size     = flag.Int("size", 256, "data size")
+	keyCount = flag.Int("n", 10e5, "Number of keys to insert (used by Load test)")
 	fsync    = flag.Bool("fsync", false, "fsync")
 	s        = flag.String("s", "map", "store type")
 	data     = make([]byte, *size)
@@ -55,10 +56,26 @@ func main() {
 		name = name + "/nofsync"
 	}
 
+	testLoad(name, store)
 	testSet(name, store)
 	testGet(name, store)
 	testGetSet(name, store)
 	testDelete(name, store)
+}
+
+// test load
+func testLoad(name string, store kvbench.Store) {
+	var keyList, valList [][]byte
+	for i := uint64(0); i < uint64(*keyCount); i++ {
+		keyList = append(keyList, genKey(i))
+		valList = append(valList, data)
+	}
+	start := time.Now()
+	err := store.PSet(keyList, valList)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s load test inserted: %d entries; took: %s s\n", name, *keyCount, time.Since(start))
 }
 
 // test get

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -19,7 +19,7 @@ var (
 	duration = flag.Duration("d", time.Minute, "test duration for each case")
 	c        = flag.Int("c", runtime.NumCPU(), "concurrent goroutines")
 	size     = flag.Int("size", 256, "data size")
-	keyCount = flag.Int("n", 10e5, "Number of keys to insert (used by Load test)")
+	keyCount = flag.Int("n", 10e5, "Number of keys to insert in batch write test)")
 	fsync    = flag.Bool("fsync", false, "fsync")
 	s        = flag.String("s", "map", "store type")
 	data     = make([]byte, *size)
@@ -56,15 +56,15 @@ func main() {
 		name = name + "/nofsync"
 	}
 
-	testLoad(name, store)
+	testBatchWrite(name, store)
 	testSet(name, store)
 	testGet(name, store)
 	testGetSet(name, store)
 	testDelete(name, store)
 }
 
-// test load
-func testLoad(name string, store kvbench.Store) {
+// test batch writes
+func testBatchWrite(name string, store kvbench.Store) {
 	var keyList, valList [][]byte
 	for i := uint64(0); i < uint64(*keyCount); i++ {
 		keyList = append(keyList, genKey(i))


### PR DESCRIPTION
This PR 
 - Modifies badger.PSet(..) to use `badger.WriteBatch`
 - Add a new `testBatchWrite` test which tries to insert a fixed number of keys in the store as fast as possible.

Fixes https://github.com/smallnest/kvbench/issues/8
Todo

- [ ] Update readme.md to include batch write numbers.