### PR TITLE
Close write batch after using it

### DIFF
--- a/rocksdbstore.go
+++ b/rocksdbstore.go
@@ -57,6 +57,7 @@ func (s *rocksdbStore) Close() error {
 
 func (s *rocksdbStore) PSet(keys, vals [][]byte) error {
 	wb := rocksdb.NewWriteBatch()
+	defer wb.Destroy()
 
 	for i, k := range keys {
 		wb.Put(k, vals[i])


### PR DESCRIPTION
Rocksdb write batch will not release the memory until `wb.Destroy` is called. This PR also reduces the memory usage of rocksdb wirtebatch.